### PR TITLE
environment is required for clusters

### DIFF
--- a/lib/clusters.nix
+++ b/lib/clusters.nix
@@ -56,7 +56,9 @@ let
         default = { };
         type = types.attrsOf (types.submodule clusterAppsOpts);
       };
-
+      environment = mkOption {
+        type = types.str;
+      };
       _resources = mkOption {
         default = { };
         type = types.attrsOf types.anything;


### PR DESCRIPTION
This will add required option `environment` to the `clusterOpts` since it is copied as a `label` under `metadata.labels` by the `mkPerClusterApps`.